### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/Cogito.Extensions.Options.Autofac/Cogito.Extensions.Options.Autofac.csproj
+++ b/Cogito.Extensions.Options.Autofac/Cogito.Extensions.Options.Autofac.csproj
@@ -4,7 +4,16 @@
         <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
         <Description>Various additions to Microsoft.Extensions.Options for Autofac.</Description>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    </PropertyGroup>
+    
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
     <ItemGroup>
         <PackageReference Include="Cogito.Autofac.DependencyInjection" Version="2.2.5" />

--- a/Cogito.Extensions.Options.Configuration.Autofac/Cogito.Extensions.Options.Configuration.Autofac.csproj
+++ b/Cogito.Extensions.Options.Configuration.Autofac/Cogito.Extensions.Options.Configuration.Autofac.csproj
@@ -4,7 +4,16 @@
         <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
         <Description>Various additions to Microsoft.Extensions.Options for Autofac.</Description>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    </PropertyGroup>
+    
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
     <ItemGroup>
         <ProjectReference Include="..\Cogito.Extensions.Options.Autofac\Cogito.Extensions.Options.Autofac.csproj" />

--- a/Cogito.Extensions.Options.Configuration/Cogito.Extensions.Options.Configuration.csproj
+++ b/Cogito.Extensions.Options.Configuration/Cogito.Extensions.Options.Configuration.csproj
@@ -4,7 +4,16 @@
         <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
         <Description>Various additions to Microsoft.Extensions.Options.</Description>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    </PropertyGroup>
+    
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.1" />

--- a/Cogito.Extensions.Options/Cogito.Extensions.Options.csproj
+++ b/Cogito.Extensions.Options/Cogito.Extensions.Options.csproj
@@ -4,7 +4,16 @@
         <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
         <Description>Various additions to Microsoft.Extensions.Options.</Description>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    </PropertyGroup>
+    
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.1" />


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
